### PR TITLE
chore: upgrade wireshark support from 4.0 to 4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["epan-sys", "wsdf-derive", "wsdf"]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ DNS, showcased below.
 
 ![DNS dissector showcase](https://raw.githubusercontent.com/ghpr-asia/wsdf/main/docs/dns_dissector.gif)
 
-wsdf has been tested on Linux against Wireshark 4.0.
+wsdf has been tested on Linux against Wireshark 4.4.
 
 **License**
 

--- a/build-examples.sh
+++ b/build-examples.sh
@@ -4,7 +4,7 @@
 # Helper script to build all our example dissectors, and copies them to where Wireshark will search
 #
 cargo build --examples
-epan_dir=~/.local/lib/wireshark/plugins/4.0/epan/
+epan_dir=~/.local/lib/wireshark/plugins/4.4/epan/
 for file in wsdf/examples/*
 do
 	filename=$(basename -- "$file")

--- a/docs/CONTRIBUTING
+++ b/docs/CONTRIBUTING
@@ -2,7 +2,7 @@ Thank you for thinking of contributing to wsdf. This document tries to give you
 an overview of the codebase. Please supplement this with the documentation on
 docs.rs for a fuller understanding.
 
-Before working on wsdf, ensure that Wireshark version 4.0 is installed along
+Before working on wsdf, ensure that Wireshark version 4.4 is installed along
 with its header files. On some distros, this may be in a separate
 wireshark-devel package.
 

--- a/epan-sys/bindings.rs
+++ b/epan-sys/bindings.rs
@@ -27292,7 +27292,7 @@ extern "C" {
     pub fn tvb_get_ds_tvb(tvb: *mut tvbuff_t) -> *mut tvbuff;
 }
 extern "C" {
-    pub fn tvb_get_guint8(tvb: *mut tvbuff_t, offset: gint) -> guint8;
+    pub fn tvb_get_uint8(tvb: *mut tvbuff_t, offset: gint) -> guint8;
 }
 extern "C" {
     pub fn tvb_get_gint8(tvb: *mut tvbuff_t, offset: gint) -> gint8;
@@ -27394,43 +27394,43 @@ extern "C" {
     pub fn tvb_get_letohieee_double(tvb: *mut tvbuff_t, offset: gint) -> gdouble;
 }
 extern "C" {
-    pub fn tvb_get_guint16(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint16;
+    pub fn tvb_get_uint16(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint16;
 }
 extern "C" {
     pub fn tvb_get_gint16(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> gint16;
 }
 extern "C" {
-    pub fn tvb_get_guint24(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint32;
+    pub fn tvb_get_uint24(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint32;
 }
 extern "C" {
     pub fn tvb_get_gint24(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> gint32;
 }
 extern "C" {
-    pub fn tvb_get_guint32(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint32;
+    pub fn tvb_get_uint32(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint32;
 }
 extern "C" {
     pub fn tvb_get_gint32(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> gint32;
 }
 extern "C" {
-    pub fn tvb_get_guint40(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint64;
+    pub fn tvb_get_uint40(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint64;
 }
 extern "C" {
     pub fn tvb_get_gint40(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> gint64;
 }
 extern "C" {
-    pub fn tvb_get_guint48(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint64;
+    pub fn tvb_get_uint48(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint64;
 }
 extern "C" {
     pub fn tvb_get_gint48(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> gint64;
 }
 extern "C" {
-    pub fn tvb_get_guint56(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint64;
+    pub fn tvb_get_uint56(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint64;
 }
 extern "C" {
     pub fn tvb_get_gint56(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> gint64;
 }
 extern "C" {
-    pub fn tvb_get_guint64(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint64;
+    pub fn tvb_get_uint64(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> guint64;
 }
 extern "C" {
     pub fn tvb_get_gint64(tvb: *mut tvbuff_t, offset: gint, encoding: guint) -> gint64;

--- a/wsdf-derive/src/lib.rs
+++ b/wsdf-derive/src/lib.rs
@@ -40,11 +40,11 @@ impl Parse for VersionMacroInput {
 ///
 /// # Example
 ///
-/// The following usage declares a plugin version of 0.0.1, built for wireshark version 4.0.x.
+/// The following usage declares a plugin version of 0.0.1, built for wireshark version 4.4.x.
 ///
 /// ```
 /// use wsdf_derive::version;
-/// version!("0.0.1", 4, 0);
+/// version!("0.0.1", 4, 4);
 /// ```
 #[proc_macro]
 pub fn version(input: TokenStream) -> TokenStream {

--- a/wsdf-derive/src/types.rs
+++ b/wsdf-derive/src/types.rs
@@ -1142,7 +1142,7 @@ impl Primitive {
         // A closure, for convenience, to grab an integer value from the TVB
         let get_int = |typ: &str| {
             let ws_enc = match typ {
-                "guint8" | "gint8" => None,
+                "uint8" | "gint8" => None,
                 _ => Some(self.ws_enc()),
             };
             let func_name = format_ident!("tvb_get_{}", typ);
@@ -1158,10 +1158,10 @@ impl Primitive {
         };
 
         let ret = match &self.typ {
-            U8 => get_int("guint8"),
-            U16 => get_int("guint16"),
-            U32 => get_int("guint32"),
-            U64 => get_int("guint64"),
+            U8 => get_int("uint8"),
+            U16 => get_int("uint16"),
+            U32 => get_int("uint32"),
+            U64 => get_int("uint64"),
             I8 => get_int("gint8"),
             I16 => get_int("gint16"),
             I32 => get_int("gint32"),

--- a/wsdf/examples/dns.rs
+++ b/wsdf/examples/dns.rs
@@ -3,7 +3,7 @@
 use wsdf::tap::{Field, Offset, Packet};
 use wsdf::{version, Dispatch, Protocol, ProtocolField};
 
-version!("0.0.1", 4, 0);
+version!("0.0.1", 4, 4);
 
 #[derive(Protocol)]
 #[wsdf(

--- a/wsdf/examples/moldudp64.rs
+++ b/wsdf/examples/moldudp64.rs
@@ -2,7 +2,7 @@
 
 use wsdf::{version, Protocol, ProtocolField};
 
-version!("0.0.1", 4, 0);
+version!("0.0.1", 4, 4);
 
 #[derive(Protocol)]
 #[wsdf(

--- a/wsdf/examples/udp.rs
+++ b/wsdf/examples/udp.rs
@@ -2,7 +2,7 @@
 
 use wsdf::{version, Protocol};
 
-version!("0.0.1", 4, 0);
+version!("0.0.1", 4, 4);
 
 // The ip.proto field obtained from http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xml
 

--- a/wsdf/src/lib.rs
+++ b/wsdf/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ```rust
 //! // lib.rs
-//! wsdf::version!("0.0.1", 4, 0);
+//! wsdf::version!("0.0.1", 4, 4);
 //!
 //! #[derive(wsdf::Protocol)]
 //! #[wsdf(decode_from = [("ip.proto", 17)])]
@@ -46,7 +46,7 @@
 //! ```
 //!
 //! * The **`wsdf::version!` macro** specifies the plugin version as 0.0.1, built for Wireshark
-//! version 4.0.X. This information is required by Wireshark when loading the plugin.
+//! version 4.4.X. This information is required by Wireshark when loading the plugin.
 //! * The protocol itself should **derive `wsdf::Protocol`**. Since this is UDP, the dissector is
 //! registered to the `"ip.proto"` dissector table, and also sets up the `"udp.port"` dissector
 //! table for subdissectors to use. More details about these annotations can be found in the
@@ -65,7 +65,7 @@
 //! this file to Wireshark's [plugin
 //! folder](https://www.wireshark.org/docs/wsug_html_chunked/ChPluginFolders.html) will allow
 //! Wireshark or tshark to load it upon startup. On Linux, this is at
-//! `~/.local/lib/wireshark/plugins/4.0/epan/`.
+//! `~/.local/lib/wireshark/plugins/4.4/epan/`.
 //!
 //! # Types
 //!

--- a/wsdf/tests/should_fail/bitwise_or_more_than_two_display.stderr
+++ b/wsdf/tests/should_fail/bitwise_or_more_than_two_display.stderr
@@ -2,4 +2,4 @@ error: expected a string literal
  --> tests/should_fail/bitwise_or_more_than_two_display.rs:9:22
   |
 9 |     #[wsdf(display = "SEP_COLON" | "BASE_SHOW_ASCII_PRINTABLE" | "SEP_SPACE")]
-  |                      ^^^^^^^^^^^
+  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/wsdf/tests/should_fail/dispatch_based_on_struct.stderr
+++ b/wsdf/tests/should_fail/dispatch_based_on_struct.stderr
@@ -3,3 +3,11 @@ error: this field cannot be used to dispatch enums
   |
 9 |     bar: Bar,
   |     ^^^
+
+warning: unused variable: `bar`
+  --> tests/should_fail/dispatch_based_on_struct.rs:24:21
+   |
+24 |     fn dispatch_bar(bar: &Bar) -> usize {
+   |                     ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
+   |
+   = note: `#[warn(unused_variables)]` on by default

--- a/wsdf/tests/should_fail/union.stderr
+++ b/wsdf/tests/should_fail/union.stderr
@@ -1,5 +1,8 @@
 error: only structs can derive Protocol
  --> tests/should_fail/union.rs:6:1
   |
-6 | union MyUnion {
-  | ^^^^^
+6 | / union MyUnion {
+7 | |     f1: u32,
+8 | |     f2: f32,
+9 | | }
+  | |_^

--- a/wsdf/tests/should_fail/unknown_container_attr.stderr
+++ b/wsdf/tests/should_fail/unknown_container_attr.stderr
@@ -2,4 +2,4 @@ error: unrecognized attribute
  --> tests/should_fail/unknown_container_attr.rs:6:8
   |
 6 | #[wsdf(foo = "bar")] // Unknown meta item
-  |        ^^^
+  |        ^^^^^^^^^^^

--- a/wsdf/tests/simple/version.rs
+++ b/wsdf/tests/simple/version.rs
@@ -1,6 +1,6 @@
 use wsdf::version;
 
-version!("0.0.1", 4, 0);
+version!("0.0.1", 4, 4);
 
 fn main() {
     assert_eq!(
@@ -8,5 +8,5 @@ fn main() {
         ['0' as i8, '.' as i8, '0' as i8, '.' as i8, '1' as i8, 0_i8]
     );
     assert_eq!(plugin_want_major, 4_i32);
-    assert_eq!(plugin_want_minor, 0_i32);
+    assert_eq!(plugin_want_minor, 4_i32);
 }


### PR DESCRIPTION
It looks like the developers of Wireshark decided to deprecate the `tvb_get_guintX` and `tvb_get_gintX`-methods (and more) in Wireshark 4.4, which is what I run on my setup. This aims to make the crate compatible with Wireshark 4.4, though I'm uncertain how compatible it is with older Wireshark versions.

I have tested so that it works on Wireshark 4.4 but I have not tested on earlier versions. I also did a very simple change and didn't regenerate the bindings, just some `sed`-magic to change the functions. There may be other functions deprecated that will be unsupported. 

The reason is simply that when I ran a compiled dissector that used `u32`s, e.g. as a `len_field` for a `Vec<u8>`, it couldn't find said function due to linking to another version. 

The functions are still visible in the Wireshark source, but I imagine the inlining makes them disappear when it's compiled so they allow the old interface until they can remove it in a future version. 

I would assume the changes to the `*.stderr`-files are due to me running Rust nightly or being generated with at least a somewhat newer version than when they were created. 

- [x] `tvb_get_guintX`-support
- [ ] `tvb_get_gintX`-support